### PR TITLE
Optimize database lookup queries

### DIFF
--- a/src/commands/search/mandarinSearchPage.ts
+++ b/src/commands/search/mandarinSearchPage.ts
@@ -78,18 +78,14 @@ async function searchEnglish(term: string, limit = 100) {
     const beforeFindAll = performance.now();
     const matchingEntries: any = await CEDICT.findAll({
         where: {
-            [Op.or]: [
-                {
-                    glossary: {
-                        [Op.substring]: `${term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&').trim()}`,
-                    }
-                },
-                // {
-                //     searchablePinyin: {
-                //         [Op.startsWith]: `${term}`
-                //     }
-                // },
-            ]
+            glossary: {
+                [Op.substring]: `${term.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&').trim()}`,
+            }
+            // {
+            //     searchablePinyin: {
+            //         [Op.startsWith]: `${term}`
+            //     }
+            // },
         }
     })
     const afterFindAll = performance.now();


### PR DESCRIPTION
The initial query with a number of [Op.or] operands seems to be slower. [Op.iLike] also seems to be slower than [Op.startsWith] (which translates to the same SQL as [Op.like]), [Op.regexp] is slower than [Op.substring].